### PR TITLE
feat: UI improvements, multi-server, global shortcut

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,8 @@ const store = new Store({
   defaults: {
     servers: [],
     activeServerId: null,
-    history: []
+    history: [],
+    skipQuickConfirm: false
   }
 });
 
@@ -129,9 +130,18 @@ function clearHistory(olderThanMs) {
   store.set('history', history.filter(e => new Date(e.timestamp).getTime() > cutoff));
 }
 
+function getSkipQuickConfirm() {
+  return store.get('skipQuickConfirm', false);
+}
+
+function setSkipQuickConfirm(val) {
+  store.set('skipQuickConfirm', !!val);
+}
+
 module.exports = {
   getConfig, setConfig,
   getServers, getActiveServer, getActiveServerId, setActiveServer,
   addServer, updateServer, deleteServer,
-  addHistoryEntry, getHistory, clearHistory
+  addHistoryEntry, getHistory, clearHistory,
+  getSkipQuickConfirm, setSkipQuickConfirm
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,8 @@ const store = new Store({
     servers: [],
     activeServerId: null,
     history: [],
-    skipQuickConfirm: false
+    skipQuickConfirm: false,
+    globalShortcut: 'CommandOrControl+Option+Control+P'
   }
 });
 
@@ -138,10 +139,19 @@ function setSkipQuickConfirm(val) {
   store.set('skipQuickConfirm', !!val);
 }
 
+function getGlobalShortcut() {
+  return store.get('globalShortcut', 'CommandOrControl+Option+Control+P');
+}
+
+function setGlobalShortcut(shortcut) {
+  store.set('globalShortcut', shortcut);
+}
+
 module.exports = {
   getConfig, setConfig,
   getServers, getActiveServer, getActiveServerId, setActiveServer,
   addServer, updateServer, deleteServer,
   addHistoryEntry, getHistory, clearHistory,
-  getSkipQuickConfirm, setSkipQuickConfirm
+  getSkipQuickConfirm, setSkipQuickConfirm,
+  getGlobalShortcut, setGlobalShortcut
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,34 +1,114 @@
 const Store = require('electron-store');
+const crypto = require('crypto');
 
 const store = new Store({
   defaults: {
-    host: '',
-    port: 22,
-    username: '',
-    privateKeyPath: '~/.ssh/id_rsa',
-    password: '',
-    remotePath: '/home/user/screenshots',
+    servers: [],
+    activeServerId: null,
     history: []
   }
 });
 
+// --- Migration from flat config ---
+function migrateIfNeeded() {
+  // If old flat config keys exist, migrate to servers array
+  if (store.has('host') && !store.has('_migrated')) {
+    const id = crypto.randomUUID();
+    const server = {
+      id,
+      name: 'Default',
+      host: store.get('host', ''),
+      port: store.get('port', 22),
+      username: store.get('username', ''),
+      privateKeyPath: store.get('privateKeyPath', '~/.ssh/id_rsa'),
+      password: store.get('password', ''),
+      remotePath: store.get('remotePath', '/home/user/screenshots')
+    };
+
+    // Only migrate if there's actually a configured server
+    if (server.host) {
+      store.set('servers', [server]);
+      store.set('activeServerId', id);
+    }
+
+    // Clean up old keys
+    store.delete('host');
+    store.delete('port');
+    store.delete('username');
+    store.delete('privateKeyPath');
+    store.delete('password');
+    store.delete('remotePath');
+    store.set('_migrated', true);
+  }
+}
+
+migrateIfNeeded();
+
+// --- Server CRUD ---
+function getServers() {
+  return store.get('servers') || [];
+}
+
+function getActiveServerId() {
+  return store.get('activeServerId');
+}
+
+function getActiveServer() {
+  const servers = getServers();
+  const activeId = getActiveServerId();
+  return servers.find(s => s.id === activeId) || servers[0] || null;
+}
+
+function setActiveServer(id) {
+  store.set('activeServerId', id);
+}
+
+function addServer(server) {
+  const id = crypto.randomUUID();
+  const entry = { id, name: server.name || 'Untitled', ...server, id };
+  const servers = getServers();
+  servers.push(entry);
+  store.set('servers', servers);
+  store.set('activeServerId', id);
+  return entry;
+}
+
+function updateServer(id, config) {
+  const servers = getServers();
+  const idx = servers.findIndex(s => s.id === id);
+  if (idx === -1) return null;
+  servers[idx] = { ...servers[idx], ...config, id };
+  store.set('servers', servers);
+  return servers[idx];
+}
+
+function deleteServer(id) {
+  let servers = getServers();
+  servers = servers.filter(s => s.id !== id);
+  store.set('servers', servers);
+  // If we deleted the active server, switch to first remaining
+  if (getActiveServerId() === id) {
+    store.set('activeServerId', servers.length > 0 ? servers[0].id : null);
+  }
+}
+
+// --- Legacy compat (used by upload-screenshot) ---
 function getConfig() {
-  return {
-    host: store.get('host'),
-    port: store.get('port'),
-    username: store.get('username'),
-    privateKeyPath: store.get('privateKeyPath'),
-    password: store.get('password'),
-    remotePath: store.get('remotePath')
+  return getActiveServer() || {
+    host: '', port: 22, username: '',
+    privateKeyPath: '~/.ssh/id_rsa', password: '',
+    remotePath: '/home/user/screenshots'
   };
 }
 
 function setConfig(config) {
-  for (const [key, value] of Object.entries(config)) {
-    store.set(key, value);
+  const active = getActiveServer();
+  if (active) {
+    updateServer(active.id, config);
   }
 }
 
+// --- History ---
 function addHistoryEntry(entry) {
   const history = store.get('history') || [];
   history.unshift(entry);
@@ -49,4 +129,9 @@ function clearHistory(olderThanMs) {
   store.set('history', history.filter(e => new Date(e.timestamp).getTime() > cutoff));
 }
 
-module.exports = { getConfig, setConfig, addHistoryEntry, getHistory, clearHistory };
+module.exports = {
+  getConfig, setConfig,
+  getServers, getActiveServer, getActiveServerId, setActiveServer,
+  addServer, updateServer, deleteServer,
+  addHistoryEntry, getHistory, clearHistory
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,4 +39,14 @@ function getHistory() {
   return store.get('history') || [];
 }
 
-module.exports = { getConfig, setConfig, addHistoryEntry, getHistory };
+function clearHistory(olderThanMs) {
+  if (olderThanMs === null) {
+    store.set('history', []);
+    return;
+  }
+  const cutoff = Date.now() - olderThanMs;
+  const history = store.get('history') || [];
+  store.set('history', history.filter(e => new Date(e.timestamp).getTime() > cutoff));
+}
+
+module.exports = { getConfig, setConfig, addHistoryEntry, getHistory, clearHistory };

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, clipboard } = require('electron');
+const { app, BrowserWindow, ipcMain, clipboard, globalShortcut, nativeImage, Notification } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -7,10 +7,12 @@ const {
   getConfig, setConfig,
   getServers, getActiveServer, setActiveServer,
   addServer, updateServer, deleteServer,
-  addHistoryEntry, getHistory, clearHistory
+  addHistoryEntry, getHistory, clearHistory,
+  getSkipQuickConfirm, setSkipQuickConfirm
 } = require('./lib/config');
 
 let mainWindow;
+let confirmWindow = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -30,7 +32,137 @@ function createWindow() {
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'));
 }
 
-app.whenReady().then(createWindow);
+// --- Shared upload logic ---
+async function performUpload(imageBuffer, thumbnail) {
+  const config = getConfig();
+
+  if (!config.host || !config.username || !config.remotePath) {
+    return { success: false, error: 'Please configure your server settings first.' };
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const filename = `screenshot_${timestamp}.png`;
+  const tempPath = path.join(os.tmpdir(), filename);
+
+  try {
+    const buffer = Buffer.from(imageBuffer);
+    fs.writeFileSync(tempPath, buffer);
+
+    const remotePath = config.remotePath.replace(/\/$/, '');
+    const remoteFilePath = `${remotePath}/${filename}`;
+
+    await uploadFile(config, tempPath, remoteFilePath);
+
+    fs.unlinkSync(tempPath);
+    clipboard.writeText(remoteFilePath);
+
+    addHistoryEntry({
+      filename,
+      remotePath: remoteFilePath,
+      host: config.host,
+      timestamp: new Date().toISOString(),
+      thumbnail: thumbnail || null
+    });
+
+    return { success: true, remotePath: remoteFilePath };
+  } catch (err) {
+    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+    return { success: false, error: err.message };
+  }
+}
+
+// --- Global shortcut: quick transmit from clipboard ---
+function handleQuickTransmit() {
+  const img = clipboard.readImage();
+  if (img.isEmpty()) {
+    new Notification({ title: 'Image Mule', body: 'No image in clipboard.' }).show();
+    return;
+  }
+
+  const pngBuffer = img.toPNG();
+  const dataUrl = `data:image/png;base64,${pngBuffer.toString('base64')}`;
+
+  // Generate thumbnail using nativeImage resize
+  const thumb = img.resize({ width: 100 });
+  const thumbDataUrl = `data:image/png;base64,${thumb.toPNG().toString('base64')}`;
+
+  if (getSkipQuickConfirm()) {
+    // Upload directly without confirmation
+    performUpload(Array.from(pngBuffer), thumbDataUrl).then(result => {
+      if (result.success) {
+        new Notification({ title: 'Image Mule', body: `Transmitted. Path copied.` }).show();
+      } else {
+        new Notification({ title: 'Image Mule', body: `Upload failed: ${result.error}` }).show();
+      }
+    });
+    return;
+  }
+
+  // Show confirmation window
+  if (confirmWindow && !confirmWindow.isDestroyed()) {
+    confirmWindow.focus();
+    return;
+  }
+
+  confirmWindow = new BrowserWindow({
+    width: 400,
+    height: 380,
+    resizable: false,
+    alwaysOnTop: true,
+    frame: false,
+    backgroundColor: '#111110',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload-confirm.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  confirmWindow.loadFile(path.join(__dirname, 'renderer', 'confirm.html'));
+
+  confirmWindow.webContents.once('did-finish-load', () => {
+    confirmWindow.webContents.send('show-image', dataUrl);
+  });
+
+  // One-time listener for this confirmation
+  const handler = (event, response) => {
+    if (!response.confirmed) {
+      if (confirmWindow && !confirmWindow.isDestroyed()) confirmWindow.close();
+      confirmWindow = null;
+      return;
+    }
+
+    if (response.skipFuture) {
+      setSkipQuickConfirm(true);
+    }
+
+    performUpload(Array.from(pngBuffer), thumbDataUrl).then(result => {
+      if (confirmWindow && !confirmWindow.isDestroyed()) confirmWindow.close();
+      confirmWindow = null;
+      if (result.success) {
+        new Notification({ title: 'Image Mule', body: `Transmitted. Path copied.` }).show();
+      } else {
+        new Notification({ title: 'Image Mule', body: `Upload failed: ${result.error}` }).show();
+      }
+    });
+  };
+
+  ipcMain.once('confirm-upload', handler);
+
+  confirmWindow.on('closed', () => {
+    ipcMain.removeListener('confirm-upload', handler);
+    confirmWindow = null;
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  globalShortcut.register('CommandOrControl+Option+Control+P', handleQuickTransmit);
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
@@ -52,47 +184,7 @@ ipcMain.handle('save-config', (event, config) => {
 });
 
 ipcMain.handle('upload-screenshot', async (event, imageBuffer, thumbnail) => {
-  const config = getConfig();
-
-  if (!config.host || !config.username || !config.remotePath) {
-    return { success: false, error: 'Please configure your server settings first.' };
-  }
-
-  // Write buffer to temp file
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const filename = `screenshot_${timestamp}.png`;
-  const tempPath = path.join(os.tmpdir(), filename);
-
-  try {
-    const buffer = Buffer.from(imageBuffer);
-    fs.writeFileSync(tempPath, buffer);
-
-    const remotePath = config.remotePath.replace(/\/$/, '');
-    const remoteFilePath = `${remotePath}/${filename}`;
-
-    await uploadFile(config, tempPath, remoteFilePath);
-
-    // Clean up temp file
-    fs.unlinkSync(tempPath);
-
-    // Copy remote path to clipboard
-    clipboard.writeText(remoteFilePath);
-
-    // Record in history
-    addHistoryEntry({
-      filename,
-      remotePath: remoteFilePath,
-      host: config.host,
-      timestamp: new Date().toISOString(),
-      thumbnail: thumbnail || null
-    });
-
-    return { success: true, remotePath: remoteFilePath };
-  } catch (err) {
-    // Clean up temp file on error
-    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
-    return { success: false, error: err.message };
-  }
+  return performUpload(imageBuffer, thumbnail);
 });
 
 ipcMain.handle('get-history', () => {
@@ -141,4 +233,12 @@ ipcMain.handle('test-connection', async () => {
   } catch (err) {
     return { success: false, error: err.message };
   }
+});
+
+// --- Quick confirm setting ---
+ipcMain.handle('get-skip-quick-confirm', () => getSkipQuickConfirm());
+
+ipcMain.handle('set-skip-quick-confirm', (event, val) => {
+  setSkipQuickConfirm(val);
+  return { success: true };
 });

--- a/main.js
+++ b/main.js
@@ -8,7 +8,8 @@ const {
   getServers, getActiveServer, setActiveServer,
   addServer, updateServer, deleteServer,
   addHistoryEntry, getHistory, clearHistory,
-  getSkipQuickConfirm, setSkipQuickConfirm
+  getSkipQuickConfirm, setSkipQuickConfirm,
+  getGlobalShortcut, setGlobalShortcut
 } = require('./lib/config');
 
 let mainWindow;
@@ -155,9 +156,19 @@ function handleQuickTransmit() {
   });
 }
 
+function registerQuickTransmitShortcut() {
+  globalShortcut.unregisterAll();
+  const shortcut = getGlobalShortcut();
+  try {
+    globalShortcut.register(shortcut, handleQuickTransmit);
+  } catch (err) {
+    console.error(`Failed to register shortcut "${shortcut}":`, err.message);
+  }
+}
+
 app.whenReady().then(() => {
   createWindow();
-  globalShortcut.register('CommandOrControl+Option+Control+P', handleQuickTransmit);
+  registerQuickTransmitShortcut();
 });
 
 app.on('will-quit', () => {
@@ -240,5 +251,14 @@ ipcMain.handle('get-skip-quick-confirm', () => getSkipQuickConfirm());
 
 ipcMain.handle('set-skip-quick-confirm', (event, val) => {
   setSkipQuickConfirm(val);
+  return { success: true };
+});
+
+// --- Global shortcut setting ---
+ipcMain.handle('get-global-shortcut', () => getGlobalShortcut());
+
+ipcMain.handle('set-global-shortcut', (event, shortcut) => {
+  setGlobalShortcut(shortcut);
+  registerQuickTransmitShortcut();
   return { success: true };
 });

--- a/main.js
+++ b/main.js
@@ -10,9 +10,9 @@ let mainWindow;
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: 520,
-    height: 680,
+    height: 520,
     minWidth: 420,
-    minHeight: 580,
+    minHeight: 460,
     titleBarStyle: 'hiddenInset',
     backgroundColor: '#111110',
     webPreferences: {

--- a/main.js
+++ b/main.js
@@ -3,7 +3,12 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { uploadFile } = require('./lib/sftp');
-const { getConfig, setConfig, addHistoryEntry, getHistory, clearHistory } = require('./lib/config');
+const {
+  getConfig, setConfig,
+  getServers, getActiveServer, setActiveServer,
+  addServer, updateServer, deleteServer,
+  addHistoryEntry, getHistory, clearHistory
+} = require('./lib/config');
 
 let mainWindow;
 
@@ -96,6 +101,29 @@ ipcMain.handle('get-history', () => {
 
 ipcMain.handle('copy-to-clipboard', (event, text) => {
   clipboard.writeText(text);
+  return { success: true };
+});
+
+// --- Server management ---
+ipcMain.handle('get-servers', () => getServers());
+
+ipcMain.handle('get-active-server', () => getActiveServer());
+
+ipcMain.handle('set-active-server', (event, id) => {
+  setActiveServer(id);
+  return { success: true };
+});
+
+ipcMain.handle('add-server', (event, server) => {
+  return addServer(server);
+});
+
+ipcMain.handle('update-server', (event, id, config) => {
+  return updateServer(id, config);
+});
+
+ipcMain.handle('delete-server', (event, id) => {
+  deleteServer(id);
   return { success: true };
 });
 

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ ipcMain.handle('save-config', (event, config) => {
   return { success: true };
 });
 
-ipcMain.handle('upload-screenshot', async (event, imageBuffer) => {
+ipcMain.handle('upload-screenshot', async (event, imageBuffer, thumbnail) => {
   const config = getConfig();
 
   if (!config.host || !config.username || !config.remotePath) {
@@ -78,7 +78,8 @@ ipcMain.handle('upload-screenshot', async (event, imageBuffer) => {
       filename,
       remotePath: remoteFilePath,
       host: config.host,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      thumbnail: thumbnail || null
     });
 
     return { success: true, remotePath: remoteFilePath };

--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ async function performUpload(imageBuffer, thumbnail) {
   }
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const filename = `screenshot_${timestamp}.png`;
+  const filename = `image_${timestamp}.png`;
   const tempPath = path.join(os.tmpdir(), filename);
 
   try {

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { uploadFile } = require('./lib/sftp');
-const { getConfig, setConfig, addHistoryEntry, getHistory } = require('./lib/config');
+const { getConfig, setConfig, addHistoryEntry, getHistory, clearHistory } = require('./lib/config');
 
 let mainWindow;
 
@@ -96,6 +96,11 @@ ipcMain.handle('get-history', () => {
 
 ipcMain.handle('copy-to-clipboard', (event, text) => {
   clipboard.writeText(text);
+  return { success: true };
+});
+
+ipcMain.handle('clear-history', (event, olderThanMs) => {
+  clearHistory(olderThanMs);
   return { success: true };
 });
 

--- a/preload-confirm.js
+++ b/preload-confirm.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('confirmApi', {
+  onShowImage: (callback) => ipcRenderer.on('show-image', (event, dataUrl) => callback(dataUrl)),
+  confirmUpload: (skipFuture) => ipcRenderer.send('confirm-upload', { confirmed: true, skipFuture }),
+  cancelUpload: () => ipcRenderer.send('confirm-upload', { confirmed: false })
+});

--- a/preload.js
+++ b/preload.js
@@ -6,5 +6,6 @@ contextBridge.exposeInMainWorld('api', {
   uploadScreenshot: (imageBuffer, thumbnail) => ipcRenderer.invoke('upload-screenshot', imageBuffer, thumbnail),
   testConnection: () => ipcRenderer.invoke('test-connection'),
   getHistory: () => ipcRenderer.invoke('get-history'),
-  copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text)
+  copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
+  clearHistory: (olderThanMs) => ipcRenderer.invoke('clear-history', olderThanMs)
 });

--- a/preload.js
+++ b/preload.js
@@ -14,5 +14,8 @@ contextBridge.exposeInMainWorld('api', {
   setActiveServer: (id) => ipcRenderer.invoke('set-active-server', id),
   addServer: (server) => ipcRenderer.invoke('add-server', server),
   updateServer: (id, config) => ipcRenderer.invoke('update-server', id, config),
-  deleteServer: (id) => ipcRenderer.invoke('delete-server', id)
+  deleteServer: (id) => ipcRenderer.invoke('delete-server', id),
+  // Quick transmit settings
+  getSkipQuickConfirm: () => ipcRenderer.invoke('get-skip-quick-confirm'),
+  setSkipQuickConfirm: (val) => ipcRenderer.invoke('set-skip-quick-confirm', val)
 });

--- a/preload.js
+++ b/preload.js
@@ -17,5 +17,7 @@ contextBridge.exposeInMainWorld('api', {
   deleteServer: (id) => ipcRenderer.invoke('delete-server', id),
   // Quick transmit settings
   getSkipQuickConfirm: () => ipcRenderer.invoke('get-skip-quick-confirm'),
-  setSkipQuickConfirm: (val) => ipcRenderer.invoke('set-skip-quick-confirm', val)
+  setSkipQuickConfirm: (val) => ipcRenderer.invoke('set-skip-quick-confirm', val),
+  getGlobalShortcut: () => ipcRenderer.invoke('get-global-shortcut'),
+  setGlobalShortcut: (shortcut) => ipcRenderer.invoke('set-global-shortcut', shortcut)
 });

--- a/preload.js
+++ b/preload.js
@@ -3,7 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('api', {
   getConfig: () => ipcRenderer.invoke('get-config'),
   saveConfig: (config) => ipcRenderer.invoke('save-config', config),
-  uploadScreenshot: (imageBuffer) => ipcRenderer.invoke('upload-screenshot', imageBuffer),
+  uploadScreenshot: (imageBuffer, thumbnail) => ipcRenderer.invoke('upload-screenshot', imageBuffer, thumbnail),
   testConnection: () => ipcRenderer.invoke('test-connection'),
   getHistory: () => ipcRenderer.invoke('get-history'),
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text)

--- a/preload.js
+++ b/preload.js
@@ -7,5 +7,12 @@ contextBridge.exposeInMainWorld('api', {
   testConnection: () => ipcRenderer.invoke('test-connection'),
   getHistory: () => ipcRenderer.invoke('get-history'),
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
-  clearHistory: (olderThanMs) => ipcRenderer.invoke('clear-history', olderThanMs)
+  clearHistory: (olderThanMs) => ipcRenderer.invoke('clear-history', olderThanMs),
+  // Server management
+  getServers: () => ipcRenderer.invoke('get-servers'),
+  getActiveServer: () => ipcRenderer.invoke('get-active-server'),
+  setActiveServer: (id) => ipcRenderer.invoke('set-active-server', id),
+  addServer: (server) => ipcRenderer.invoke('add-server', server),
+  updateServer: (id, config) => ipcRenderer.invoke('update-server', id, config),
+  deleteServer: (id) => ipcRenderer.invoke('delete-server', id)
 });

--- a/renderer/confirm.html
+++ b/renderer/confirm.html
@@ -119,7 +119,7 @@
   </style>
 </head>
 <body>
-  <div class="confirm-header">Transmit this screenshot?</div>
+  <div class="confirm-header">Transmit this image?</div>
   <div class="confirm-preview">
     <img id="confirm-image" />
   </div>

--- a/renderer/confirm.html
+++ b/renderer/confirm.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Confirm Transmit</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      padding: 16px;
+      gap: 12px;
+      background: var(--bg);
+      overflow: hidden;
+    }
+
+    .confirm-header {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+      text-align: center;
+    }
+
+    .confirm-preview {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      min-height: 0;
+    }
+
+    .confirm-preview img {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      border-radius: var(--radius-md);
+    }
+
+    .confirm-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .confirm-actions button {
+      flex: 1;
+      padding: 10px;
+      border-radius: var(--radius-md);
+      font-family: var(--font-display);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+    }
+
+    #confirm-btn {
+      background: var(--accent);
+      color: var(--bg);
+    }
+
+    #confirm-btn:hover {
+      background: var(--accent-hover);
+    }
+
+    #cancel-btn {
+      background: var(--surface-raised);
+      color: var(--text-muted);
+      border: 1px solid var(--border-strong);
+    }
+
+    #cancel-btn:hover {
+      color: var(--text);
+    }
+
+    .confirm-skip {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      justify-content: center;
+    }
+
+    .confirm-skip input[type="checkbox"] {
+      width: 14px;
+      height: 14px;
+      accent-color: var(--accent);
+      padding: 0;
+    }
+
+    .confirm-skip label {
+      font-size: 11px;
+      text-transform: none;
+      letter-spacing: 0;
+      cursor: pointer;
+    }
+
+    .confirm-status {
+      font-size: 12px;
+      font-family: var(--font-mono);
+      text-align: center;
+      color: var(--text-muted);
+      min-height: 16px;
+    }
+
+    .confirm-status.uploading {
+      color: var(--accent);
+    }
+
+    .confirm-status.success {
+      color: var(--success);
+    }
+
+    .confirm-status.error {
+      color: var(--error);
+    }
+  </style>
+</head>
+<body>
+  <div class="confirm-header">Transmit this screenshot?</div>
+  <div class="confirm-preview">
+    <img id="confirm-image" />
+  </div>
+  <div class="confirm-skip">
+    <input type="checkbox" id="skip-checkbox" />
+    <label for="skip-checkbox">Don't ask again</label>
+  </div>
+  <div id="confirm-status" class="confirm-status"></div>
+  <div class="confirm-actions">
+    <button id="cancel-btn">Cancel</button>
+    <button id="confirm-btn">Transmit</button>
+  </div>
+  <script src="confirm.js"></script>
+</body>
+</html>

--- a/renderer/confirm.js
+++ b/renderer/confirm.js
@@ -1,0 +1,24 @@
+const confirmBtn = document.getElementById('confirm-btn');
+const cancelBtn = document.getElementById('cancel-btn');
+const skipCheckbox = document.getElementById('skip-checkbox');
+const confirmImage = document.getElementById('confirm-image');
+
+window.confirmApi.onShowImage((dataUrl) => {
+  confirmImage.src = dataUrl;
+});
+
+confirmBtn.addEventListener('click', () => {
+  window.confirmApi.confirmUpload(skipCheckbox.checked);
+});
+
+cancelBtn.addEventListener('click', () => {
+  window.confirmApi.cancelUpload();
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    window.confirmApi.confirmUpload(skipCheckbox.checked);
+  } else if (e.key === 'Escape') {
+    window.confirmApi.cancelUpload();
+  }
+});

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -31,6 +31,12 @@
       <button id="clear-btn" style="display:none;">✕</button>
     </div>
 
+    <!-- Server selector -->
+    <div class="server-bar">
+      <select id="server-select" class="server-select"></select>
+      <button id="add-server-btn" class="server-action" title="New Server">+</button>
+    </div>
+
     <!-- Collapsible Settings -->
     <button id="settings-toggle" class="settings-toggle">
       <span class="settings-icon">⚙</span>
@@ -38,6 +44,10 @@
       <span class="settings-chevron">›</span>
     </button>
     <div id="settings-panel" class="settings" style="display: none;">
+      <div class="field">
+        <label for="server-name">Name</label>
+        <input type="text" id="server-name" placeholder="My Server" />
+      </div>
       <div class="field">
         <label for="host">Server</label>
         <input type="text" id="host" placeholder="myserver.com" />
@@ -61,6 +71,7 @@
         <input type="text" id="remotePath" placeholder="/home/user/screenshots" />
       </div>
       <div class="settings-actions">
+        <button id="delete-server-btn" class="secondary danger">Delete Server</button>
         <button id="test-btn" class="secondary">Test Connection</button>
       </div>
     </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -75,6 +75,12 @@
       <button id="send-btn" disabled>Transmit and Copy File Path</button>
     </div>
 
+    <!-- Shortcut hint -->
+    <div class="shortcut-hint">
+      <span class="shortcut-label">Global shortcut:</span>
+      <button id="shortcut-display" class="shortcut-keys" title="Click to change shortcut"></button>
+    </div>
+
     <!-- Status -->
     <div id="status" class="status"></div>
   </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -76,6 +76,17 @@
 
   <!-- History page -->
   <div class="container page" id="page-history" style="display: none;">
+    <div class="history-toolbar">
+      <div class="clear-wrapper">
+        <button id="clear-history-btn" class="secondary">Clear...</button>
+        <div id="clear-dropdown" class="clear-dropdown" style="display: none;">
+          <button class="clear-option" data-range="hour">Last Hour</button>
+          <button class="clear-option" data-range="day">Last 24 Hours</button>
+          <button class="clear-option" data-range="month">Last 30 Days</button>
+          <button class="clear-option" data-range="all">All History</button>
+        </div>
+      </div>
+    </div>
     <div id="history-list" class="history-list">
       <div class="history-empty">No transmissions yet.</div>
     </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -24,7 +24,7 @@
     <div id="drop-zone" tabindex="0">
       <div id="placeholder">
         <div class="icon">📋</div>
-        <p>Paste or drop a screenshot</p>
+        <p>Paste or drop an image</p>
         <span class="hint">Cmd+V · drag &amp; drop</span>
       </div>
       <img id="preview" style="display:none;" />
@@ -79,6 +79,7 @@
     <div class="shortcut-hint">
       <span class="shortcut-label">Global shortcut:</span>
       <button id="shortcut-display" class="shortcut-keys" title="Click to change shortcut"></button>
+      <button id="reset-shortcut" class="shortcut-reset" title="Reset to default">reset</button>
     </div>
 
     <!-- Status -->

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -31,18 +31,12 @@
       <button id="clear-btn" style="display:none;">✕</button>
     </div>
 
-    <!-- Server selector -->
+    <!-- Server bar: selector + gear + add -->
     <div class="server-bar">
       <select id="server-select" class="server-select"></select>
+      <button id="settings-toggle" class="server-action" title="Server Settings">⚙</button>
       <button id="add-server-btn" class="server-action" title="New Server">+</button>
     </div>
-
-    <!-- Collapsible Settings -->
-    <button id="settings-toggle" class="settings-toggle">
-      <span class="settings-icon">⚙</span>
-      <span class="settings-label">Server Settings</span>
-      <span class="settings-chevron">›</span>
-    </button>
     <div id="settings-panel" class="settings" style="display: none;">
       <div class="field">
         <label for="server-name">Name</label>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -384,5 +384,83 @@ document.querySelectorAll('.clear-option').forEach(btn => {
   });
 });
 
+// --- Global shortcut display & editor ---
+const shortcutDisplay = document.getElementById('shortcut-display');
+let isRecording = false;
+
+// Convert Electron accelerator to readable format
+function formatShortcut(accelerator) {
+  if (!accelerator) return '';
+  const isMac = navigator.platform.includes('Mac');
+  return accelerator
+    .replace(/CommandOrControl/g, isMac ? '⌘' : 'Ctrl')
+    .replace(/Control/g, isMac ? '⌃' : 'Ctrl')
+    .replace(/Option/g, isMac ? '⌥' : 'Alt')
+    .replace(/Alt/g, isMac ? '⌥' : 'Alt')
+    .replace(/Shift/g, isMac ? '⇧' : 'Shift')
+    .replace(/\+/g, '');
+}
+
+// Convert keydown event to Electron accelerator string
+function keyEventToAccelerator(e) {
+  const parts = [];
+  if (e.metaKey) parts.push('CommandOrControl');
+  if (e.ctrlKey && !e.metaKey) parts.push('Control');
+  if (e.altKey) parts.push('Option');
+  if (e.shiftKey) parts.push('Shift');
+
+  const key = e.key;
+  // Only accept letter/number/F-key as the final key
+  if (key.length === 1 && /[a-zA-Z0-9]/.test(key)) {
+    parts.push(key.toUpperCase());
+  } else if (/^F\d+$/.test(key)) {
+    parts.push(key);
+  } else {
+    return null; // modifier-only press, ignore
+  }
+
+  if (parts.length < 2) return null; // need at least one modifier + key
+  return parts.join('+');
+}
+
+async function loadShortcut() {
+  const shortcut = await window.api.getGlobalShortcut();
+  shortcutDisplay.textContent = formatShortcut(shortcut);
+}
+
+shortcutDisplay.addEventListener('click', () => {
+  if (isRecording) return;
+  isRecording = true;
+  shortcutDisplay.textContent = 'Press shortcut...';
+  shortcutDisplay.classList.add('recording');
+
+  const handler = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.key === 'Escape') {
+      // Cancel recording
+      isRecording = false;
+      shortcutDisplay.classList.remove('recording');
+      document.removeEventListener('keydown', handler, true);
+      loadShortcut();
+      return;
+    }
+
+    const accelerator = keyEventToAccelerator(e);
+    if (!accelerator) return; // still pressing modifiers
+
+    isRecording = false;
+    shortcutDisplay.classList.remove('recording');
+    document.removeEventListener('keydown', handler, true);
+
+    await window.api.setGlobalShortcut(accelerator);
+    shortcutDisplay.textContent = formatShortcut(accelerator);
+  };
+
+  document.addEventListener('keydown', handler, true);
+});
+
 // --- Init ---
 loadServers();
+loadShortcut();

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -11,6 +11,7 @@ const settingsPanel = document.getElementById('settings-panel');
 // Config fields
 const fields = ['host', 'username', 'port', 'privateKeyPath', 'remotePath'];
 let currentImageBuffer = null;
+let currentThumbnail = null;
 
 // --- Tabs ---
 const tabs = document.querySelectorAll('.tab');
@@ -65,15 +66,34 @@ for (const field of fields) {
 }
 
 // --- Image handling ---
+function generateThumbnail(dataUrl, maxWidth = 100) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = maxWidth / img.width;
+      const canvas = document.createElement('canvas');
+      canvas.width = maxWidth;
+      canvas.height = img.height * scale;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL('image/jpeg', 0.6));
+    };
+    img.src = dataUrl;
+  });
+}
+
 function setImage(blob) {
   const reader = new FileReader();
-  reader.onload = (e) => {
+  reader.onload = async (e) => {
     preview.src = e.target.result;
     preview.style.display = 'block';
     placeholder.style.display = 'none';
     clearBtn.style.display = 'flex';
     dropZone.classList.add('has-image');
     sendBtn.disabled = false;
+
+    // Generate thumbnail for history
+    currentThumbnail = await generateThumbnail(e.target.result);
 
     // Convert to buffer for upload
     const bufReader = new FileReader();
@@ -93,6 +113,7 @@ function clearImage() {
   dropZone.classList.remove('has-image');
   sendBtn.disabled = true;
   currentImageBuffer = null;
+  currentThumbnail = null;
   setStatus('', '');
 }
 
@@ -151,7 +172,7 @@ sendBtn.addEventListener('click', async () => {
   sendBtn.classList.add('uploading');
   setStatus('Connecting...', 'info');
 
-  const result = await window.api.uploadScreenshot(currentImageBuffer);
+  const result = await window.api.uploadScreenshot(currentImageBuffer, currentThumbnail);
 
   sendBtn.classList.remove('uploading');
   sendBtn.textContent = 'Transmit and Copy File Path';
@@ -202,13 +223,18 @@ async function loadHistory() {
     return;
   }
 
-  historyList.innerHTML = history.map(entry => {
+  historyList.innerHTML = history.map((entry, i) => {
     const date = new Date(entry.timestamp);
     const timeStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
       + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
 
+    const thumbHtml = entry.thumbnail
+      ? `<img class="history-thumb" src="${entry.thumbnail}" alt="" />`
+      : `<div class="history-thumb-placeholder">📋</div>`;
+
     return `
-      <div class="history-item">
+      <div class="history-item" data-index="${i}">
+        ${thumbHtml}
         <div class="history-info">
           <span class="history-filename">${entry.filename}</span>
           <span class="history-meta">${entry.host} · ${timeStr}</span>
@@ -217,12 +243,16 @@ async function loadHistory() {
           Copy Path
         </button>
       </div>
+      ${entry.thumbnail ? `<div class="history-preview" data-for="${i}" style="display:none;">
+        <img src="${entry.thumbnail}" alt="Preview" />
+      </div>` : ''}
     `;
   }).join('');
 
   // Attach copy handlers
   historyList.querySelectorAll('.history-copy').forEach(btn => {
-    btn.addEventListener('click', async () => {
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
       const pathText = btn.dataset.path;
       await window.api.copyToClipboard(pathText);
       const original = btn.textContent;
@@ -232,6 +262,23 @@ async function loadHistory() {
         btn.textContent = original;
         btn.classList.remove('copied');
       }, 1500);
+    });
+  });
+
+  // Attach click-to-expand handlers
+  historyList.querySelectorAll('.history-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const idx = item.dataset.index;
+      const preview = historyList.querySelector(`.history-preview[data-for="${idx}"]`);
+      if (!preview) return;
+      const isOpen = preview.style.display !== 'none';
+      // Close all previews
+      historyList.querySelectorAll('.history-preview').forEach(p => p.style.display = 'none');
+      historyList.querySelectorAll('.history-item').forEach(i => i.classList.remove('expanded'));
+      if (!isOpen) {
+        preview.style.display = 'block';
+        item.classList.add('expanded');
+      }
     });
   });
 }

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -283,5 +283,30 @@ async function loadHistory() {
   });
 }
 
+// --- Clear history ---
+const clearHistoryBtn = document.getElementById('clear-history-btn');
+const clearDropdown = document.getElementById('clear-dropdown');
+
+clearHistoryBtn.addEventListener('click', (e) => {
+  e.stopPropagation();
+  clearDropdown.style.display = clearDropdown.style.display === 'none' ? 'block' : 'none';
+});
+
+document.addEventListener('click', () => {
+  clearDropdown.style.display = 'none';
+});
+
+const RANGES = { hour: 3600000, day: 86400000, month: 2592000000, all: null };
+
+document.querySelectorAll('.clear-option').forEach(btn => {
+  btn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const range = btn.dataset.range;
+    await window.api.clearHistory(RANGES[range]);
+    clearDropdown.style.display = 'none';
+    loadHistory();
+  });
+});
+
 // --- Init ---
 loadConfig();

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -7,8 +7,11 @@ const testBtn = document.getElementById('test-btn');
 const status = document.getElementById('status');
 const settingsToggle = document.getElementById('settings-toggle');
 const settingsPanel = document.getElementById('settings-panel');
+const serverSelect = document.getElementById('server-select');
+const addServerBtn = document.getElementById('add-server-btn');
+const deleteServerBtn = document.getElementById('delete-server-btn');
 
-// Config fields
+// Config fields (excluding server-name which is handled separately)
 const fields = ['host', 'username', 'port', 'privateKeyPath', 'remotePath'];
 let currentImageBuffer = null;
 let currentThumbnail = null;
@@ -38,20 +41,85 @@ settingsToggle.addEventListener('click', () => {
   settingsToggle.classList.toggle('open', !isOpen);
 });
 
-// --- Load saved config ---
-async function loadConfig() {
-  const config = await window.api.getConfig();
+// --- Server selector ---
+async function loadServers() {
+  const servers = await window.api.getServers();
+  const active = await window.api.getActiveServer();
+
+  serverSelect.innerHTML = '';
+
+  if (servers.length === 0) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No servers configured';
+    serverSelect.appendChild(opt);
+    deleteServerBtn.style.display = 'none';
+    return;
+  }
+
+  servers.forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s.id;
+    opt.textContent = s.name || s.host || 'Untitled';
+    if (active && s.id === active.id) opt.selected = true;
+    serverSelect.appendChild(opt);
+  });
+
+  deleteServerBtn.style.display = servers.length > 0 ? '' : 'none';
+  loadActiveServerConfig();
+}
+
+async function loadActiveServerConfig() {
+  const server = await window.api.getActiveServer();
+  if (!server) return;
+
+  document.getElementById('server-name').value = server.name || '';
   for (const field of fields) {
     const el = document.getElementById(field);
-    if (el && config[field]) {
-      el.value = config[field];
+    if (el && server[field] !== undefined) {
+      el.value = server[field];
     }
   }
 }
 
+serverSelect.addEventListener('change', async () => {
+  const id = serverSelect.value;
+  if (id) {
+    await window.api.setActiveServer(id);
+    loadActiveServerConfig();
+  }
+});
+
+// --- Add server ---
+addServerBtn.addEventListener('click', async () => {
+  const server = await window.api.addServer({
+    name: 'New Server',
+    host: '',
+    port: 22,
+    username: '',
+    privateKeyPath: '~/.ssh/id_rsa',
+    remotePath: '/home/user/screenshots'
+  });
+  await loadServers();
+  // Open settings so user can configure
+  settingsPanel.style.display = 'flex';
+  settingsToggle.classList.add('open');
+  document.getElementById('server-name').focus();
+});
+
+// --- Delete server ---
+deleteServerBtn.addEventListener('click', async () => {
+  const id = serverSelect.value;
+  if (!id) return;
+  const name = serverSelect.options[serverSelect.selectedIndex]?.textContent || 'this server';
+  if (!confirm(`Delete "${name}"?`)) return;
+  await window.api.deleteServer(id);
+  await loadServers();
+});
+
 // --- Save config on input change ---
 function getConfigFromFields() {
-  const config = {};
+  const config = { name: document.getElementById('server-name').value };
   for (const field of fields) {
     const el = document.getElementById(field);
     config[field] = field === 'port' ? parseInt(el.value) || 22 : el.value;
@@ -59,10 +127,18 @@ function getConfigFromFields() {
   return config;
 }
 
-for (const field of fields) {
-  document.getElementById(field).addEventListener('change', async () => {
-    await window.api.saveConfig(getConfigFromFields());
-  });
+async function saveCurrentServer() {
+  const id = serverSelect.value;
+  if (!id) return;
+  const config = getConfigFromFields();
+  await window.api.updateServer(id, config);
+  // Update dropdown label
+  const opt = serverSelect.querySelector(`option[value="${id}"]`);
+  if (opt) opt.textContent = config.name || config.host || 'Untitled';
+}
+
+for (const field of ['server-name', ...fields]) {
+  document.getElementById(field).addEventListener('change', saveCurrentServer);
 }
 
 // --- Image handling ---
@@ -165,7 +241,7 @@ sendBtn.addEventListener('click', async () => {
   if (!currentImageBuffer) return;
 
   // Save config first
-  await window.api.saveConfig(getConfigFromFields());
+  await saveCurrentServer();
 
   sendBtn.disabled = true;
   sendBtn.textContent = 'Transmitting...';
@@ -198,7 +274,7 @@ document.addEventListener('keydown', (e) => {
 
 // --- Test connection ---
 testBtn.addEventListener('click', async () => {
-  await window.api.saveConfig(getConfigFromFields());
+  await saveCurrentServer();
   testBtn.textContent = 'Testing...';
   setStatus('Testing...', 'info');
 
@@ -309,4 +385,4 @@ document.querySelectorAll('.clear-option').forEach(btn => {
 });
 
 // --- Init ---
-loadConfig();
+loadServers();

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -405,23 +405,29 @@ function formatShortcut(accelerator) {
 function keyEventToAccelerator(e) {
   const parts = [];
   if (e.metaKey) parts.push('CommandOrControl');
-  if (e.ctrlKey && !e.metaKey) parts.push('Control');
+  if (e.ctrlKey) parts.push('Control');
   if (e.altKey) parts.push('Option');
   if (e.shiftKey) parts.push('Shift');
 
-  const key = e.key;
-  // Only accept letter/number/F-key as the final key
-  if (key.length === 1 && /[a-zA-Z0-9]/.test(key)) {
-    parts.push(key.toUpperCase());
-  } else if (/^F\d+$/.test(key)) {
-    parts.push(key);
-  } else {
-    return null; // modifier-only press, ignore
+  // Use e.code to get the physical key (e.key returns garbled chars with Option held)
+  const code = e.code;
+  let key = null;
+  if (/^Key[A-Z]$/.test(code)) {
+    key = code.slice(3); // KeyP → P
+  } else if (/^Digit\d$/.test(code)) {
+    key = code.slice(5); // Digit1 → 1
+  } else if (/^F\d+$/.test(code)) {
+    key = code; // F1, F12
   }
+
+  if (!key) return null; // modifier-only press or unsupported key
+  parts.push(key);
 
   if (parts.length < 2) return null; // need at least one modifier + key
   return parts.join('+');
 }
+
+const DEFAULT_SHORTCUT = 'CommandOrControl+Option+Control+P';
 
 async function loadShortcut() {
   const shortcut = await window.api.getGlobalShortcut();
@@ -459,6 +465,13 @@ shortcutDisplay.addEventListener('click', () => {
   };
 
   document.addEventListener('keydown', handler, true);
+});
+
+// --- Reset shortcut ---
+const resetShortcutBtn = document.getElementById('reset-shortcut');
+resetShortcutBtn.addEventListener('click', async () => {
+  await window.api.setGlobalShortcut(DEFAULT_SHORTCUT);
+  shortcutDisplay.textContent = formatShortcut(DEFAULT_SHORTCUT);
 });
 
 // --- Init ---

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -233,47 +233,6 @@ body {
   color: var(--text);
 }
 
-/* Settings toggle */
-.settings-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 10px 12px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-muted);
-  font-family: var(--font-display);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: border-color 0.15s ease-out, color 0.15s ease-out;
-}
-
-.settings-toggle:hover {
-  border-color: var(--border-strong);
-  color: var(--text);
-}
-
-.settings-icon {
-  font-size: 14px;
-}
-
-.settings-label {
-  flex: 1;
-  text-align: left;
-}
-
-.settings-chevron {
-  font-size: 14px;
-  transition: transform 0.15s ease-out;
-}
-
-.settings-toggle.open .settings-chevron {
-  transform: rotate(90deg);
-}
-
 /* Settings panel */
 .settings {
   flex-direction: column;
@@ -281,9 +240,12 @@ body {
   padding: 12px;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-top: none;
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  margin-top: -6px;
+  border-radius: var(--radius-md);
+}
+
+.server-action.open {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .field {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -396,10 +396,53 @@ input::placeholder {
   background: var(--surface);
   border-radius: var(--radius-md);
   transition: background 0.15s ease-out;
+  cursor: pointer;
 }
 
 .history-item:hover {
   background: var(--surface-raised);
+}
+
+.history-item.expanded {
+  background: var(--surface-raised);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.history-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.history-thumb-placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.history-preview {
+  background: var(--surface-raised);
+  padding: 12px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  margin-top: -2px;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.history-preview img {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: var(--radius-sm);
+  object-fit: contain;
 }
 
 .history-info {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -179,6 +179,60 @@ body {
   background: rgba(196, 90, 74, 0.8);
 }
 
+/* Server selector */
+.server-bar {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.server-select {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%237a756c'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 30px;
+}
+
+.server-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.server-action {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease-out, color 0.15s ease-out;
+  -webkit-app-region: no-drag;
+  flex-shrink: 0;
+}
+
+.server-action:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
 /* Settings toggle */
 .settings-toggle {
   display: flex;
@@ -253,7 +307,7 @@ body {
 
 .settings-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   margin-top: 4px;
 }
 
@@ -339,6 +393,18 @@ input::placeholder {
 .secondary:hover {
   border-color: var(--accent);
   color: var(--text);
+}
+
+.secondary.danger {
+  border-color: var(--error);
+  color: var(--error);
+  opacity: 0.7;
+}
+
+.secondary.danger:hover {
+  opacity: 1;
+  border-color: var(--error);
+  color: var(--error);
 }
 
 /* Status */

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -374,6 +374,52 @@ input::placeholder {
   word-break: break-all;
 }
 
+/* History toolbar */
+.history-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.clear-wrapper {
+  position: relative;
+}
+
+.clear-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  z-index: 10;
+  min-width: 160px;
+}
+
+.clear-option {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease-out;
+}
+
+.clear-option:hover {
+  background: var(--accent-soft);
+}
+
+.clear-option:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+
 /* History */
 .history-list {
   display: flex;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -369,6 +369,48 @@ input::placeholder {
   color: var(--error);
 }
 
+/* Shortcut hint */
+.shortcut-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.shortcut-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.shortcut-keys {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease-out, color 0.15s ease-out;
+}
+
+.shortcut-keys:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.shortcut-keys.recording {
+  border-color: var(--accent);
+  color: var(--accent);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
 /* Status */
 .status {
   font-size: 12px;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -97,7 +97,7 @@ body {
 /* Drop zone */
 #drop-zone {
   position: relative;
-  border: 1px dashed var(--border-strong);
+  border: 2px dashed rgba(237, 232, 223, 0.25);
   border-radius: var(--radius-lg);
   min-height: 200px;
   display: flex;
@@ -107,7 +107,7 @@ body {
   transition: border-color 0.15s ease-out, background 0.15s ease-out;
   outline: none;
   flex-shrink: 0;
-  background: var(--surface);
+  background: rgba(26, 25, 23, 0.8);
 }
 
 #drop-zone:hover,
@@ -131,23 +131,23 @@ body {
 }
 
 #placeholder .icon {
-  font-size: 32px;
-  margin-bottom: 8px;
-  opacity: 0.5;
+  font-size: 36px;
+  margin-bottom: 10px;
+  opacity: 0.8;
 }
 
 #placeholder p {
-  font-size: 14px;
-  font-weight: 500;
-  margin-bottom: 4px;
-  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--text);
 }
 
 #placeholder .hint {
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-muted);
-  opacity: 0.5;
+  opacity: 0.7;
 }
 
 #preview {
@@ -404,6 +404,23 @@ input::placeholder {
   border-color: var(--accent);
   color: var(--accent);
   animation: pulse 1s ease-in-out infinite;
+}
+
+.shortcut-reset {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s ease-out, color 0.15s ease-out;
+  padding: 0;
+}
+
+.shortcut-reset:hover {
+  opacity: 1;
+  color: var(--accent);
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary

- **Fix dead space**: Shrink window from 680→520px
- **History thumbnails**: Inline 40x40 previews, click to expand
- **Clear history**: Dropdown to clear last hour / day / 30 days / all
- **Multi-server support**: Named server profiles with dropdown selector, auto-migration from single-server config
- **Compact server bar**: Merged server selector + gear + add into one row
- **Global shortcut**: `Cmd+Option+Ctrl+P` to transmit clipboard image with confirmation popup
- **Configurable shortcut**: Click to record new shortcut, reset to default
- **Brighter drop zone**: More visible borders, text, and icon
- **Renamed "screenshot" → "image"** throughout UI

## Test plan

- [ ] `npm start` — window should be compact, no dead space
- [ ] Paste an image, transmit — verify history shows thumbnail
- [ ] Click history item to expand preview
- [ ] Clear history with each time range
- [ ] Create/switch/delete server profiles
- [ ] Press global shortcut with image in clipboard — confirmation popup appears
- [ ] Check "Don't ask again" — next shortcut press uploads directly
- [ ] Click shortcut display to record new shortcut
- [ ] Click reset to restore default
- [ ] Verify drop zone text says "image" not "screenshot"

🤖 Generated with [Claude Code](https://claude.com/claude-code)